### PR TITLE
fix: add multiple credential-issued listeners

### DIFF
--- a/int/tests/test_holder.py
+++ b/int/tests/test_holder.py
@@ -99,6 +99,9 @@ async def issue_credential(
     await wait_for_message(
         msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-received"
     )
+    await wait_for_message(
+        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
+    )
     credentials_list = await asyncio.wait_for(
         get_issue_credential_records.asyncio(client=backchannel), timeout=40
     )
@@ -151,11 +154,11 @@ async def test_holder_credential_exchange(
         credential_offer_accept["@type"]
         == "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-request-sent"
     )
-    await wait_for_message(
-        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
-    )
     credential_received = await wait_for_message(
         msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credential-received"
+    )
+    await wait_for_message(
+        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
     )
     records = await asyncio.wait_for(
         get_issue_credential_records.asyncio(client=backchannel), timeout=20
@@ -173,6 +176,12 @@ async def test_credentials_get_list(
     wait_for_message,
 ):
     cred = issue_credential
+    await wait_for_message(
+        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
+    )
+    await wait_for_message(
+        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
+    )
     credentials_get_list = await connection.send_and_await_reply_async(
         {
             "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credentials-get-list"
@@ -187,6 +196,3 @@ async def test_credentials_get_list(
         == "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-holder/0.1/credentials-list"
     )
     assert cred_set.issubset(cred_get_list_set)
-    await wait_for_message(
-        msg_type="did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued"
-    )


### PR DESCRIPTION
Add enough listeners to remove all `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/admin-issuer/0.1/credential-issued` notification messages from the response/request queue.
 
Signed-off-by: Char Howland <char@indicio.tech>