### PR TITLE
feature/add health checks

### DIFF
--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -33,9 +33,9 @@ services:
       --preserve-exchange-records
       --public-invites
     healthcheck:
-      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
-      start_period: 30s
-      interval: 7s
+      test: nc -z localhost 3002
+      start_period: 5s
+      interval: 1s
       timeout: 5s
       retries: 5
 
@@ -45,9 +45,9 @@ services:
       - "3002:3002"
     command: --host 0.0.0.0 --port 3002 --log-level debug
     healthcheck:
-      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3002/status/live" | grep "200" > /dev/null
-      start_period: 30s
-      interval: 7s
+      test: nc -z localhost 3002
+      start_period: 5s
+      interval: 1s
       timeout: 5s
       retries: 5
 

--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -33,9 +33,9 @@ services:
       --preserve-exchange-records
       --public-invites
     healthcheck:
-      test: nc -z localhost 3001
-      start_period: 5s
-      interval: 1s
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
       timeout: 5s
       retries: 5
 

--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 #**************************************************************
 # integration level test agents                                *
 #***************************************************************
@@ -33,12 +32,24 @@ services:
       --auto-store-credential
       --preserve-exchange-records
       --public-invites
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
 
   echo:
     image: ghcr.io/indicio-tech/echo-agent:0.1.2
     ports:
       - "3002:3002"
     command: --host 0.0.0.0 --port 3002 --log-level debug
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3002/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
 
   #*************************************************************
   # tester: drives tests for acapy_plugin_toolbox in a         *
@@ -62,5 +73,7 @@ services:
       - SUITE_HOST=echo
       - SUITE_PORT=3002
     depends_on:
-      - agent
-      - echo
+      agent:
+        condition: service_healthy
+      echo:
+        condition: service_healthy

--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       --preserve-exchange-records
       --public-invites
     healthcheck:
-      test: nc -z localhost 3002
+      test: nc -z localhost 3001
       start_period: 5s
       interval: 1s
       timeout: 5s


### PR DESCRIPTION
Adding health checks to `int/docker-compose.yml` 

Passed all tests, using (a) `poetry shell`, (b) `docker compose -f int/docker-compose.yml build`, (c) `docker compose -f int/docker-compose.yml run tests`. 

Unideally, uses different health checks for the `agent` and `echo` service, but it works.

Credit to Colton Wolkins for debugging! :) Credit to Micah for finding `echo` health check